### PR TITLE
修复 `截图无限裁切` 功能导致的崩溃问题

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 }
 
 android {
-    compileSdk = 32
-    buildToolsVersion = "32.0.0"
+    compileSdk = 33
+    buildToolsVersion = "33.0.0"
     defaultConfig {
         applicationId = "com.lt2333.simplicitytools"
         minSdk = 31
-        targetSdk = 32
+        targetSdk = 33
         versionCode = 67
         versionName = "1.6.6"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
         <activity
             android:name=".activity.SettingsActivity"
             android:exported="true"
-            android:screenOrientation="portrait"
             android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/lt2333/simplicitytools/hook/app/screenshot/UnlockUnlimitedCropping.kt
+++ b/app/src/main/java/com/lt2333/simplicitytools/hook/app/screenshot/UnlockUnlimitedCropping.kt
@@ -10,7 +10,7 @@ object UnlockUnlimitedCropping : HookRegister() {
     override fun init() {
         //截图无限裁切
         findMethod("com.miui.gallery.editor.photo.screen.crop.ScreenCropView\$b") {
-            name == "a"
+            name == "a" && parameterCount == 0 && returnType == Int::class.java
         }.hookBefore {
             hasEnable("unlock_unlimited_cropping") {
                 it.result = 0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
+        classpath("com.android.tools.build:gradle:7.2.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle.kts files


### PR DESCRIPTION
* 同时更新依赖
* 允许应用横屏