### PR TITLE
为 7.4.9-230220.0.1 版本的手机管家修复 去除游戏自动连招黑名单

### DIFF
--- a/app/src/main/java/com/lt2333/simplicitytools/hooks/rules/all/securitycenter/RemoveMacroBlacklistForAll.kt
+++ b/app/src/main/java/com/lt2333/simplicitytools/hooks/rules/all/securitycenter/RemoveMacroBlacklistForAll.kt
@@ -28,6 +28,19 @@ object RemoveMacroBlacklistForAll : HookRegister() {
                 }
                 letter++
             }
+            findMethod("q7.m0") {
+                name == "n" && parameterTypes[0] == ArrayList::class.java
+            }.hookBefore { param ->
+                param.args[0] = "[]"
+            }
+
+            findMethod("q7.m0"){
+                name == "g" && parameterTypes[0] == String::class.java
+            }.hookReturnConstant(false)
+
+            findMethod("w6.b"){
+                name == "e" && parameterTypes[0] == Context::class.java && parameterTypes[1] == String::class.java
+            }.hookReturnConstant(true)
         }
     }
 


### PR DESCRIPTION
思路方案来自 @laukase